### PR TITLE
deploy on preprod

### DIFF
--- a/.github/workflows/preprod-deploy.yml
+++ b/.github/workflows/preprod-deploy.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: off-net
+    concurrency: off-net
     steps:
     - name: Checkout git repository
       uses: appleboy/ssh-action@1d1b21ca96111b1eb4c03c21c14ebb971d2200f6  # v0.1.4


### PR DESCRIPTION
The previous commit on **main** is also to be considered (pushed directly by mistake)

In fact this adds the [.github/workflows/preprod-deploy.yml file](https://github.com/openfoodfacts/openfoodfacts-web/blob/deploy-preprod-test/.github/workflows/preprod-deploy.yml)

This branch is named `deploy-` so that it will test deployment on preprod.

@stephanegigandet you have to set the secrets for an off-net environment:

- HOST
- PROXY_HOST
- USERNAME
- SSH_PRIVATE_KEY

It should be the same as off-server.