### PR TITLE
fix: h1 tag must be the first tag

### DIFF
--- a/lang/en/texts/index-pro.html
+++ b/lang/en/texts/index-pro.html
@@ -1,6 +1,6 @@
+<h1>Open Food Facts for producers</h1>
 
 <div class="row text-center show-when-no-access-to-producers-platform">
-	<h1>Open Food Facts for producers</h1>
   <div class="medium-12 columns">
 
 <p>A completely free platform to allow manufacturers to easily manage the data and photos of their products on Open Food Facts.</p>

--- a/lang/fr/texts/index-pro.html
+++ b/lang/fr/texts/index-pro.html
@@ -1,6 +1,6 @@
+<h1>Open Food Facts pour les producteurs</h1>
 
 <div class="row text-center show-when-no-access-to-producers-platform">
-	<h1>Open Food Facts pour les producteurs</h1>
   <div class="medium-12 columns">
 
 <p>Une plateforme entièrement gratuite pour permettre aux fabricants de gérer facilement les photos et données de leurs produits sur Open Food Facts.</p>


### PR DESCRIPTION
Fixes https://github.com/openfoodfacts/openfoodfacts-server/issues/7377

the h1 tag must be the first tag, and it must be outside any other tag, as we have special behaviours for page titles and for the index.