### PR TITLE
ci: remove cron for Crowdin

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - crowdin-trigger
-  schedule:
-   - cron: "0 7 * * *"
 jobs:
   synchronize-with-crowdin-classic:
     name: Synchronize with crowdin


### PR DESCRIPTION
### What
- ci: remove cron for Crowdin. The sync is now handled by Crowdin. CRON readds files at the root of crowdin in addition to the more organized sync made by crowdin