### PR TITLE
fix: Italian index.html used to redirect to error pages

### DIFF
--- a/lang/it/texts/index.html
+++ b/lang/it/texts/index.html
@@ -6,7 +6,7 @@
         <h2>Scopri</h2>
         <p>Open Pet Food Facts è un database di alimenti per animali realizzato da tutti, per tutti. You can use it to make better choices about pet food, and as it is open data, anyone can re-use it for any purpose.</p>
       </div>
-      <a class="button round secondary small homepage-greeter__button" href="/scopri">→ <a href="/discover"> Ulteriori informazioni su Open Food Food Facts </a></a>
+      <a class="button round secondary small homepage-greeter__button" href="/discover">→ <a href="/discover"> Ulteriori informazioni su Open Food Food Facts </a></a>
     </div>
     <div class="homepage-greeter__discover--image">
       <img src="images/illustrations/globe.svg" alt="Open Food Facts" />
@@ -22,7 +22,7 @@
 exciting projects you can contribute to in many different ways.
         </p>
       </div>
-      <a class="button round secondary small homepage-greeter__button" href="/contribuire"><span class="material-icons">add_task</span>Ulteriori informazioni su come unirti a noi</a>
+      <a class="button round secondary small homepage-greeter__button" href="/contribute"><span class="material-icons">add_task</span>Ulteriori informazioni su come unirti a noi</a>
     </div>
     <div class="homepage-greeter__contribute--image">
       <img src="images/illustrations/puzzle-big.svg" alt="Open Pet Food Facts è un database di alimenti per animali realizzato da tutti, per tutti." />


### PR DESCRIPTION
### What
href links in eng to redirect to correct pages.
I guess another solution would be translating the .html files names, I don't know what the standard should be here
Marketing issue: [Italian's "Discover" and "Contribute" redirect to error pages #11
](https://github.com/openfoodfacts/openfoodfacts-marketing/issues/11)
fix openfoodfacts/openfoodfacts-marketing#11

### Screenshot

How it used to be:
<img width="452" alt="image" src="https://github.com/openfoodfacts/openfoodfacts-web/assets/22130686/59f6ec10-1a81-41f5-81b3-d15e01cf20e4">

<img width="718" alt="image" src="https://github.com/openfoodfacts/openfoodfacts-web/assets/22130686/c36fd375-c6d4-4f54-b1fc-2e711aab2421">

 