### PR TITLE
fix: Fixes un-sdg-broken-images links

### DIFF
--- a/lang/en/texts/cop26/blocks/un-sustainable-development-goals.html
+++ b/lang/en/texts/cop26/blocks/un-sustainable-development-goals.html
@@ -14,19 +14,19 @@
 
 <div class="row text-center" data-equalizer data-equalize-by-row="true">
 	<div class="medium-4 columns" data-equalizer-watch style="background: #4d9f39;">
-		<img src="https://world.openfoodfacts.org/illustrations/un-sdg-logos/EN_SDG_Goals_03.png" alt="Goal 3 – Good Health and Well-being" style="height: 140px;">
+		<img src="../../../../../html/illustrations/un-sdg-logos/EN_SDG_Goals_03.png" alt="Goal 3 – Good Health and Well-being" style="height: 140px;">
 		<h3 class="white-sdg-text">Goal 3 – Good Health and Well-being</h3>
 		<p class="white-sdg-text">By helping people choose food that is good for their health, using IARC-promoted Nutri-Score, we try to tackle UN Sustainable Development Goal #3.</p>
 	</div>
 
 	<div class="medium-4 columns" data-equalizer-watch style="background: #be8b2f;">
-		<img src="https://world.openfoodfacts.org/illustrations/un-sdg-logos/EN_SDG_Goals_12.png" alt="Goal 12 – Responsible Consumption and Production" style="height: 140px;">
+		<img src="../../../../../html/illustrations/un-sdg-logos/EN_SDG_Goals_12.png" alt="Goal 12 – Responsible Consumption and Production" style="height: 140px;">
 		<h3 class="white-sdg-text">Goal 12 – Responsible Consumption and Production</h3>
 		<p class="white-sdg-text">By helping people choose food that is good for their health and the environment, using Nutri-Score and Eco-Score we try to tackle UN Sustainable Development Goal #12, to move humanity towards sustainable consumption.</p>
 	</div>
 
 	<div class="medium-4 columns" data-equalizer-watch style="background: #3f7e44;">
-		<img src="https://world.openfoodfacts.org/illustrations/un-sdg-logos/EN_SDG_Goals_13.png" alt="Goal 13 – Climate Action" style="height: 140px;">
+		<img src="../../../../../html/illustrations/un-sdg-logos/EN_SDG_Goals_13.png" alt="Goal 13 – Climate Action" style="height: 140px;">
 		<h3 class="white-sdg-text">Goal 13 – Climate Action</h3>
 		<p class="white-sdg-text">By helping people choose food that has a lesser impact on the environment, using Eco-Score, and since food accounts for a third of the humanity's carbon emissions, we try to tackle UN Sustainable Development Goal #13, to help mitigate the current climate crisis.</p>
 	</div>
@@ -35,19 +35,19 @@
 
 <div class="row text-center" data-equalizer data-equalize-by-row="true">
 	<div class="medium-4 columns" data-equalizer-watch style="background: #0c97d9;">
-		<img src="https://world.openfoodfacts.org/illustrations/un-sdg-logos/EN_SDG_Goals_14.png" alt="Goal 14  – Life Below Water" style="height: 140px;">
+		<img src="../../../../../html/illustrations/un-sdg-logos/EN_SDG_Goals_14.png" alt="Goal 14  – Life Below Water" style="height: 140px;">
 		<h3 class="white-sdg-text">Goal 14  – Life Below Water</h3>
 		<p class="white-sdg-text">The Eco-Score takes into account many criteria aimed at ensuring the sustainable use and the preservation of halieutic resources, to help tackle UN Sustainable Development Goal #14.</p>
 	</div>
 
 	<div class="medium-4 columns" data-equalizer-watch style="background: #56c02a;">
-		<img src="https://world.openfoodfacts.org/illustrations/un-sdg-logos/EN_SDG_Goals_15.png" alt="Goal 15  – Life on land." style="height: 140px;">
+		<img src="../../../../../html/illustrations/un-sdg-logos/EN_SDG_Goals_15.png" alt="Goal 15  – Life on land." style="height: 140px;">
 		<h3 class="white-sdg-text">Goal 15  – Life on land.</h3>
 		<p class="white-sdg-text">The Eco-Score takes into account many criteria aimed at ensuring the sustainable use and the preservation of Earth's resources, to help tackle UN Sustainable Development Goal #15.</p>
 	</div>
 
 	<div class="medium-4 columns" data-equalizer-watch style="background: #18486a;">
-		<img src="https://world.openfoodfacts.org/illustrations/un-sdg-logos/EN_SDG_Goals_17.png" alt="Goal 17 – Partnerships for the goals" style="height: 140px;">
+		<img src="../../../../../html/illustrations/un-sdg-logos/EN_SDG_Goals_17.png" alt="Goal 17 – Partnerships for the goals" style="height: 140px;">
 		<h3 class="white-sdg-text">Goal 17 – Partnerships for the goals </h3>
 		<p class="white-sdg-text">If you'd like to help us achieve UN's Sustainable Development Goals, we can partner in some way: Governments, Scientists, Food Producers, Companies can help in some way achieve our objectives. Reach out at <a href="mailto:contact@openfoodfacts.org">contact@openfoodfacts.org</a></p>
 	</div>


### PR DESCRIPTION
### What
- UN SDG images are committed on this repo, yet they seem broken in production
- https://world.openfoodfacts.org/presskit
- https://world.openfoodfacts.org/illustrations/un-sdg-logos/EN_SDG_Goals_17.png
- https://github.com/openfoodfacts/openfoodfacts-web/blob/main/html/illustrations/un-sdg-logos/EN_SDG_Goals_17.png

### Fixes bug(s)
- #548 
- Images src links are updated.