### PR TITLE
feat: Parquet db bis

### DIFF
--- a/lang/aa/texts/data.html
+++ b/lang/aa/texts/data.html
@@ -57,7 +57,15 @@ They may contain graphical elements subject to copyright or other rights, that m
 
 <h3>Parquet Data Export on Hugging Face</h3>
 
-<p>A simplified of the JSONL dump is also available in the <a href="https://parquet.apache.org/">Parquet format</a>. This data format is optimized for column-oriented queries, which is particular convenient for data analysis. i.e. you can select just the columns you care about, reducing the size of the file you have to handle. You don't have to download all columns, simplifying your data-processing on entry-level computers.</p>
+<p>A simplified version of the JSONL dump is also available in the <a href="https://parquet.apache.org/">Parquet format</a>. During the conversion, we filtered columns that contains duplicated information, are used for internal debugging, or are simply irrelevant for users.
+    
+The Parquet format has proved to be handy: 
+
+<ul>
+<li>Data are organized by column, rather than by row, which saves storage space and speeds up analytics queries, i.e. you can select just the columns you care about, optimizing query performances, even on entry-level computers.</li>
+<li>Highly efficient data compression and decompression, making it good for storing and sharing big data of any kind,</li>
+<li>Supports complex data types and advanced nested data structures.</li>
+</ul
 
 The dataset is available on <a href="https://huggingface.co/datasets/openfoodfacts/product-database">Hugging Face</a>, a collaborative Machine Learning ecosystem where developers and researchers can share models and datasets. 
 <dl>
@@ -65,6 +73,8 @@ The dataset is available on <a href="https://huggingface.co/datasets/openfoodfac
  <dd><a href="https://huggingface.co/datasets/openfoodfacts/product-database/resolve/main/products.parquet">https://huggingface.co/datasets/openfoodfacts/product-database/resolve/main/products.parquet</a>
  </dd>
 </dl>
+
+Find more information in the <a href="https://wiki.openfoodfacts.org/Reusing_Open_Food_Facts_Data#Parquet_file_hosted_on_Hugging_Face_.28beta.29">Wiki</a>, including guidelines for data reuse and example queries to get started.
 
 <h3>CSV Data Export</h3>
 <p>Data for all products, or some of the products, can be downloaded in the CSV format (readable with LibreOffice, Excel and many other spreadsheet software) through the <a href="https://world.openfoodfacts.org/cgi/search.pl">advanced search form</a>.</p>

--- a/lang/aa/texts/data.html
+++ b/lang/aa/texts/data.html
@@ -55,16 +55,6 @@ They may contain graphical elements subject to copyright or other rights, that m
 
 <p>A suitable way to exploit the database is to use DuckDB, an in-process analytical tool designed to process large amount of data in a fraction of seconds. You can read our <a href="https://blog.openfoodfacts.org/en/news/food-transparency-in-the-palm-of-your-hand-explore-the-largest-open-food-database-using-duckdb-%f0%9f%a6%86x%f0%9f%8d%8a">blog post</a> where we walk you through exploring and processing the Open Food Facts database with DuckDB</p>
 
-<h3>CSV Data Export</h3>
-<p>Data for all products, or some of the products, can be downloaded in the CSV format (readable with LibreOffice, Excel and many other spreadsheet software) through the <a href="https://world.openfoodfacts.org/cgi/search.pl">advanced search form</a>.</p>
-
-<dl>
- <dt>Links</dt>
- <dd><a href="https://static.openfoodfacts.org/data/en.openfoodfacts.org.products.csv.gz">https://static.openfoodfacts.org/data/en.openfoodfacts.org.products.csv.gz</a> (compressed CSV in GZIP format: ~ 0.9 Gb, uncompressed: ~ 9 Gb)</dd>
-</dl>
-
-<p>The file encoding is Unicode UTF-8. The character that separates fields is &lt;tab&gt; (tabulation).</p>
-
 <h3>Parquet Data Export on Hugging Face</h3>
 
 <p>A cleaner version of the JSONL dump is also available in the <a href="https://parquet.apache.org/">Parquet format</a>. This data format is optimized for columnar queries, which is particular convenient for data analysis.</p>

--- a/lang/aa/texts/data.html
+++ b/lang/aa/texts/data.html
@@ -57,7 +57,7 @@ They may contain graphical elements subject to copyright or other rights, that m
 
 <h3>Parquet Data Export on Hugging Face</h3>
 
-<p>A cleaner version of the JSONL dump is also available in the <a href="https://parquet.apache.org/">Parquet format</a>. This data format is optimized for columnar queries, which is particular convenient for data analysis.</p>
+<p>A simplified of the JSONL dump is also available in the <a href="https://parquet.apache.org/">Parquet format</a>. This data format is optimized for column-oriented queries, which is particular convenient for data analysis. i.e. you can select just the columns you care about, reducing the size of the file you have to handle. You don't have to download all columns, simplifying your data-processing on entry-level computers.</p>
 
 The dataset is available on <a href="https://huggingface.co/datasets/openfoodfacts/product-database">Hugging Face</a>, a collaborative Machine Learning ecosystem where developers and researchers can share models and datasets. 
 <dl>

--- a/lang/aa/texts/data.html
+++ b/lang/aa/texts/data.html
@@ -65,6 +65,27 @@ They may contain graphical elements subject to copyright or other rights, that m
 
 <p>The file encoding is Unicode UTF-8. The character that separates fields is &lt;tab&gt; (tabulation).</p>
 
+<h3>Parquet Data Export on Hugging Face</h3>
+
+<p>A cleaner version of the JSONL dump is also available in the <a href="https://parquet.apache.org/">Parquet format</a>. This data format is optimized for columnar queries, which is particular convenient for data analysis.</p>
+
+The dataset is available on <a href="https://huggingface.co/datasets/openfoodfacts/product-database">Hugging Face</a>, a collaborative Machine Learning ecosystem where developers and researchers can share models and datasets. 
+<dl>
+ <dt>Link</dt>
+ <dd><a href="https://huggingface.co/datasets/openfoodfacts/product-database/resolve/main/products.parquet">https://huggingface.co/datasets/openfoodfacts/product-database/resolve/main/products.parquet</a>
+ </dd>
+</dl>
+
+<h3>CSV Data Export</h3>
+<p>Data for all products, or some of the products, can be downloaded in the CSV format (readable with LibreOffice, Excel and many other spreadsheet software) through the <a href="https://world.openfoodfacts.org/cgi/search.pl">advanced search form</a>.</p>
+
+<dl>
+ <dt>Links</dt>
+ <dd><a href="https://static.openfoodfacts.org/data/en.openfoodfacts.org.products.csv.gz">https://static.openfoodfacts.org/data/en.openfoodfacts.org.products.csv.gz</a> (compressed CSV in GZIP format: ~ 0.9 Gb, uncompressed: ~ 9 Gb)</dd>
+</dl>
+
+<p>The file encoding is Unicode UTF-8. The character that separates fields is &lt;tab&gt; (tabulation).</p>
+
 <h3>RDF Data Export</h3>
 <p>The database is also available in the RDF format. You can read the <a href="https://blog.openfoodfacts.org/fr/news/des-donnees-libres-et-liees-export-rdf-des-donnees">announcement in French</a>.</p>
 

--- a/lang/aa/texts/data.html
+++ b/lang/aa/texts/data.html
@@ -55,27 +55,6 @@ They may contain graphical elements subject to copyright or other rights, that m
 
 <p>A suitable way to exploit the database is to use DuckDB, an in-process analytical tool designed to process large amount of data in a fraction of seconds. You can read our <a href="https://blog.openfoodfacts.org/en/news/food-transparency-in-the-palm-of-your-hand-explore-the-largest-open-food-database-using-duckdb-%f0%9f%a6%86x%f0%9f%8d%8a">blog post</a> where we walk you through exploring and processing the Open Food Facts database with DuckDB</p>
 
-<h3>Parquet Data Export on Hugging Face</h3>
-
-<p>A simplified version of the JSONL dump is also available in the <a href="https://parquet.apache.org/">Parquet format</a>. During the conversion, we filtered columns that contains duplicated information, are used for internal debugging, or are simply irrelevant for users.
-    
-The Parquet format has proved to be handy: 
-
-<ul>
-<li>Data are organized by column, rather than by row, which saves storage space and speeds up analytics queries, i.e. you can select just the columns you care about, optimizing query performances, even on entry-level computers.</li>
-<li>Highly efficient data compression and decompression, making it good for storing and sharing big data of any kind,</li>
-<li>Supports complex data types and advanced nested data structures.</li>
-</ul
-
-The dataset is available on <a href="https://huggingface.co/datasets/openfoodfacts/product-database">Hugging Face</a>, a collaborative Machine Learning ecosystem where developers and researchers can share models and datasets. 
-<dl>
- <dt>Link</dt>
- <dd><a href="https://huggingface.co/datasets/openfoodfacts/product-database/resolve/main/products.parquet">https://huggingface.co/datasets/openfoodfacts/product-database/resolve/main/products.parquet</a>
- </dd>
-</dl>
-
-Find more information in the <a href="https://wiki.openfoodfacts.org/Reusing_Open_Food_Facts_Data#Parquet_file_hosted_on_Hugging_Face_.28beta.29">Wiki</a>, including guidelines for data reuse and example queries to get started.
-
 <h3>CSV Data Export</h3>
 <p>Data for all products, or some of the products, can be downloaded in the CSV format (readable with LibreOffice, Excel and many other spreadsheet software) through the <a href="https://world.openfoodfacts.org/cgi/search.pl">advanced search form</a>.</p>
 

--- a/lang/en/texts/data.html
+++ b/lang/en/texts/data.html
@@ -63,7 +63,7 @@ They may contain graphical elements subject to copyright or other rights, that m
 
 <ul>
 <li>Data is organized by column, rather than by row, which saves storage space and speeds up analytics queries, i.e. you can select just the columns you care about, optimizing query performances, even on entry-level computers.</li>
-<li>Highly efficient data compression and decompression, making it good for storing and sharing big data of any kind,</li>
+<li>Highly efficient data compression and decompression, making it good for storing and sharing big datasets of any kind,</li>
 <li>Supports complex data types and advanced nested data structures.</li>
 </ul>
 

--- a/lang/en/texts/data.html
+++ b/lang/en/texts/data.html
@@ -55,6 +55,28 @@ They may contain graphical elements subject to copyright or other rights, that m
 
 <p>A suitable way to exploit the database is to use DuckDB, an in-process analytical tool designed to process large amount of data in a fraction of seconds. You can read our <a href="https://blog.openfoodfacts.org/en/news/food-transparency-in-the-palm-of-your-hand-explore-the-largest-open-food-database-using-duckdb-%f0%9f%a6%86x%f0%9f%8d%8a">blog post</a> where we walk you through exploring and processing the Open Food Facts database with DuckDB</p>
 
+<h3>Parquet Data Export on Hugging Face</h3>
+
+<p>A simplified version of the JSONL dump is also available in the <a href="https://parquet.apache.org/">Parquet format</a>. During the conversion, we filtered columns that contains duplicated information, are used for internal debugging, or are simply irrelevant for users.
+    
+The Parquet format has proved to be handy: 
+
+<ul>
+<li>Data are organized by column, rather than by row, which saves storage space and speeds up analytics queries, i.e. you can select just the columns you care about, optimizing query performances, even on entry-level computers.</li>
+<li>Highly efficient data compression and decompression, making it good for storing and sharing big data of any kind,</li>
+<li>Supports complex data types and advanced nested data structures.</li>
+</ul>
+
+The dataset is available on <a href="https://huggingface.co/datasets/openfoodfacts/product-database">Hugging Face</a>, a collaborative Machine Learning ecosystem where developers and researchers can share models and datasets. 
+
+<dl>
+ <dt>Link</dt>
+ <dd><a href="https://huggingface.co/datasets/openfoodfacts/product-database/resolve/main/products.parquet">https://huggingface.co/datasets/openfoodfacts/product-database/resolve/main/products.parquet</a>
+ </dd>
+</dl>
+
+Find more information in the <a href="https://wiki.openfoodfacts.org/Reusing_Open_Food_Facts_Data#Parquet_file_hosted_on_Hugging_Face_.28beta.29">Wiki</a>, including guidelines for data reuse and example queries to get started.
+
 <h3>CSV Data Export</h3>
 <p>Data for all products, or some of the products, can be downloaded in the CSV format (readable with LibreOffice, Excel and many other spreadsheet software) through the <a href="https://world.openfoodfacts.org/cgi/search.pl">advanced search form</a>.</p>
 

--- a/lang/en/texts/data.html
+++ b/lang/en/texts/data.html
@@ -57,9 +57,9 @@ They may contain graphical elements subject to copyright or other rights, that m
 
 <h3>Parquet Data Export on Hugging Face</h3>
 
-<p>A simplified version of the JSONL dump is also available in the <a href="https://parquet.apache.org/">Parquet format</a>. During the conversion, we filtered columns that contains duplicated information, are used for internal debugging, or are simply irrelevant for users.
+<p>A simplified version of the JSONL dump is also available in the <a href="https://parquet.apache.org/">Parquet format</a>. During the conversion, we filtered columns that contains duplicated information, are used for internal debugging, or are simply irrelevant for users.</p>
     
-The Parquet format has proved to be handy: 
+<p>The Parquet format has proved to be handy:<p> 
 
 <ul>
 <li>Data are organized by column, rather than by row, which saves storage space and speeds up analytics queries, i.e. you can select just the columns you care about, optimizing query performances, even on entry-level computers.</li>
@@ -67,7 +67,7 @@ The Parquet format has proved to be handy:
 <li>Supports complex data types and advanced nested data structures.</li>
 </ul>
 
-The dataset is available on <a href="https://huggingface.co/datasets/openfoodfacts/product-database">Hugging Face</a>, a collaborative Machine Learning ecosystem where developers and researchers can share models and datasets. 
+<p>The dataset is available on <a href="https://huggingface.co/datasets/openfoodfacts/product-database">Hugging Face</a>, a collaborative Machine Learning ecosystem where developers and researchers can share models and datasets.</p>
 
 <dl>
  <dt>Link</dt>
@@ -75,7 +75,7 @@ The dataset is available on <a href="https://huggingface.co/datasets/openfoodfac
  </dd>
 </dl>
 
-Find more information in the <a href="https://wiki.openfoodfacts.org/Reusing_Open_Food_Facts_Data#Parquet_file_hosted_on_Hugging_Face_.28beta.29">Wiki</a>, including guidelines for data reuse and example queries to get started.
+</p>Find more information in the <a href="https://wiki.openfoodfacts.org/Reusing_Open_Food_Facts_Data#Parquet_file_hosted_on_Hugging_Face_.28beta.29">Wiki</a>, including guidelines for data reuse and example queries to get started.</p>
 
 <h3>CSV Data Export</h3>
 <p>Data for all products, or some of the products, can be downloaded in the CSV format (readable with LibreOffice, Excel and many other spreadsheet software) through the <a href="https://world.openfoodfacts.org/cgi/search.pl">advanced search form</a>.</p>

--- a/lang/en/texts/data.html
+++ b/lang/en/texts/data.html
@@ -71,7 +71,7 @@ They may contain graphical elements subject to copyright or other rights, that m
 
 <dl>
  <dt>Link</dt>
- <dd><a href="https://huggingface.co/datasets/openfoodfacts/product-database/resolve/main/products.parquet">https://huggingface.co/datasets/openfoodfacts/product-database/resolve/main/products.parquet</a>
+ <dd><a href="https://huggingface.co/datasets/openfoodfacts/product-database/resolve/main/food.parquet?download=true">https://huggingface.co/datasets/openfoodfacts/product-database/resolve/main/food.parquet?download=true</a>
  </dd>
 </dl>
 

--- a/lang/en/texts/data.html
+++ b/lang/en/texts/data.html
@@ -62,7 +62,7 @@ They may contain graphical elements subject to copyright or other rights, that m
 <p>The Parquet format has proved to be handy:<p> 
 
 <ul>
-<li>Data are organized by column, rather than by row, which saves storage space and speeds up analytics queries, i.e. you can select just the columns you care about, optimizing query performances, even on entry-level computers.</li>
+<li>Data is organized by column, rather than by row, which saves storage space and speeds up analytics queries, i.e. you can select just the columns you care about, optimizing query performances, even on entry-level computers.</li>
 <li>Highly efficient data compression and decompression, making it good for storing and sharing big data of any kind,</li>
 <li>Supports complex data types and advanced nested data structures.</li>
 </ul>


### PR DESCRIPTION
### What
- We recently converted the JSONL dump into the Parquet format, which is more suitable for analytic queries and lightweight.
- The dataset is hosted on the [Hugging Face platform](https://huggingface.co/datasets/openfoodfacts/product-database/tree/main).
- This commit adds a section to the data webpage to allow the database users to load the Parquet file.

### Part of 
- [PR](https://github.com/openfoodfacts/robotoff/pull/1436): Add CLI command to convert and push JSONL to Huggingface
