### PR TITLE
feat: Update build_html.py generation script for multi-project

### DIFF
--- a/.github/workflows/build-additives.yml
+++ b/.github/workflows/build-additives.yml
@@ -3,9 +3,7 @@ name: Build HTML pages for knowledge cards
 on:
   push:
     paths:
-      - 'knowledge_panels/additives/*.yml'
-      - 'knowledge_panels/ingredients/*.yml'
-      - 'knowledge_panels/nutrients/*.yml'
+      - 'knowledge_panels/**.yml'
       
 jobs:
   update-assets:

--- a/knowledge_panels/build_html.py
+++ b/knowledge_panels/build_html.py
@@ -44,7 +44,7 @@ def generate_file_path(
         root_dir: the root directory where HTML pages are located
         item: the knowledge content item
         tag_type: the target tag type
-        project_type: obf, opff, opf, off
+        flavor: obf, opff, opf, off
         country: the target country (2-letters code or 'world')
         lang: the target lang (2-letters code)
 

--- a/knowledge_panels/build_html.py
+++ b/knowledge_panels/build_html.py
@@ -57,7 +57,7 @@ def generate_file_path(
     return (
         root_dir
         / lang
-       / project_type
+       / flavor
         / "knowledge_panels"
         / tag_type
         / f"{value_tag}_{country}{category_tag_suffix}.html"

--- a/knowledge_panels/build_html.py
+++ b/knowledge_panels/build_html.py
@@ -36,13 +36,14 @@ def generate_file_path(
 ) -> Path:
     """Generate a file path unique to the knowledge content item.
 
-    The generated path depends on the `tag_type`, the `value_tag`, the
+    The generated path depends on the `project_type` `tag_type`, the `value_tag`, the
     `country` the `lang` and the `category_tag`.
 
     Args:
         root_dir: the root directory where HTML pages are located
         item: the knowledge content item
         tag_type: the target tag type
+        project_type: obf, opff, opf, off
         country: the target country (2-letters code or 'world')
         lang: the target lang (2-letters code)
 
@@ -50,10 +51,12 @@ def generate_file_path(
         Path: the path where the HTML page should be saved
     """
     category_tag_suffix = "" if item.category_tag is None else f"_{item.category_tag}"
+    project_type = "/" if item.project_type is "off" else f"/_{item.project_type}"
     value_tag = item.value_tag.replace(":", "_")
     return (
         root_dir
         / lang
+        project_type
         / "knowledge_panels"
         / tag_type
         / f"{value_tag}_{country}{category_tag_suffix}.html"
@@ -72,6 +75,7 @@ def build_content(root_dir: Path, dir_paths: list[Path]):
         dir_paths: the directories containing YAML files
     """
     logger.info("Deleting existing HTML files")
+    # probably failing here ? 
     for knowledge_panels_dir in root_dir.glob("*/knowledge_panels"):
         for tag_type_dir in knowledge_panels_dir.glob("*"):
             for file_path in tag_type_dir.glob("*.html"):
@@ -101,7 +105,7 @@ def build_content_from_file(root_dir: Path, file_path: Path):
     # tag_type is the name of the directory
     tag_type = file_path.parent.stem
 
-    if tag_type not in ("labels", "additives", "categories", "ingredients"):
+    if tag_type not in ("labels", "additives", "categories", "ingredients", "nutrients"):
         logger.info("Ignoring file %s: unknown tag type %s", file_path, tag_type)
         return
 

--- a/knowledge_panels/build_html.py
+++ b/knowledge_panels/build_html.py
@@ -57,7 +57,7 @@ def generate_file_path(
     return (
         root_dir
         / lang
-        project_type
+        / project_type
         / "knowledge_panels"
         / tag_type
         / f"{value_tag}_{country}{category_tag_suffix}.html"

--- a/knowledge_panels/build_html.py
+++ b/knowledge_panels/build_html.py
@@ -30,7 +30,7 @@ class KnowledgeContentItem(BaseModel):
 def generate_file_path(
     root_dir: Path,
     item: KnowledgeContentItem,
-    project_type: str,
+    flavor: str,
     tag_type: str,
     country: str,
     lang: str,

--- a/knowledge_panels/build_html.py
+++ b/knowledge_panels/build_html.py
@@ -52,7 +52,7 @@ def generate_file_path(
         Path: the path where the HTML page should be saved
     """
     category_tag_suffix = "" if item.category_tag is None else f"_{item.category_tag}"
-    project_type = project_type or ""
+    flavor = flavor or ""
     value_tag = item.value_tag.replace(":", "_")
     return (
         root_dir

--- a/knowledge_panels/build_html.py
+++ b/knowledge_panels/build_html.py
@@ -52,7 +52,7 @@ def generate_file_path(
         Path: the path where the HTML page should be saved
     """
     category_tag_suffix = "" if item.category_tag is None else f"_{item.category_tag}"
-    project_type = "/" if item.project_type == "off" else f"/_{item.project_type}"
+    project_type = project_type or ""
     value_tag = item.value_tag.replace(":", "_")
     return (
         root_dir

--- a/knowledge_panels/build_html.py
+++ b/knowledge_panels/build_html.py
@@ -37,7 +37,7 @@ def generate_file_path(
 ) -> Path:
     """Generate a file path unique to the knowledge content item.
 
-    The generated path depends on the `project_type` `tag_type`, the `value_tag`, the
+    The generated path depends on the `flavor` `tag_type`, the `value_tag`, the
     `country` the `lang` and the `category_tag`.
 
     Args:

--- a/knowledge_panels/build_html.py
+++ b/knowledge_panels/build_html.py
@@ -30,6 +30,7 @@ class KnowledgeContentItem(BaseModel):
 def generate_file_path(
     root_dir: Path,
     item: KnowledgeContentItem,
+    project_type: str,
     tag_type: str,
     country: str,
     lang: str,

--- a/knowledge_panels/build_html.py
+++ b/knowledge_panels/build_html.py
@@ -51,7 +51,7 @@ def generate_file_path(
         Path: the path where the HTML page should be saved
     """
     category_tag_suffix = "" if item.category_tag is None else f"_{item.category_tag}"
-    project_type = "/" if item.project_type is "off" else f"/_{item.project_type}"
+    project_type = "/" if item.project_type == "off" else f"/_{item.project_type}"
     value_tag = item.value_tag.replace(":", "_")
     return (
         root_dir

--- a/knowledge_panels/build_html.py
+++ b/knowledge_panels/build_html.py
@@ -57,7 +57,7 @@ def generate_file_path(
     return (
         root_dir
         / lang
-        / project_type
+        project_type
         / "knowledge_panels"
         / tag_type
         / f"{value_tag}_{country}{category_tag_suffix}.html"

--- a/knowledge_panels/build_html.py
+++ b/knowledge_panels/build_html.py
@@ -57,7 +57,7 @@ def generate_file_path(
     return (
         root_dir
         / lang
-        project_type
+       / project_type
         / "knowledge_panels"
         / tag_type
         / f"{value_tag}_{country}{category_tag_suffix}.html"

--- a/knowledge_panels/requirements.txt
+++ b/knowledge_panels/requirements.txt
@@ -1,4 +1,4 @@
-markdown==3.4.4
-openfoodfacts==0.1.10
-pydantic==2.4.2
-ruamel.yaml==0.17.35
+markdown==3.8
+openfoodfacts==2.5.1
+pydantic==2.11.3
+ruamel.yaml==0.18.10


### PR DESCRIPTION
### What
- feat: Update build_html.py generation script for multi-project
- fix: only remove files that will be regenerated

> [!CAUTION]
> @stephanegigandet recently changed the behavior and path in https://github.com/openfoodfacts/openfoodfacts-server/pull/11688/files, so this script needs to be adapted 