### PR TITLE
ci: Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,5 +1,8 @@
 name: "Semantic PRs"
 
+permissions:
+  contents: read
+
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/11](https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/11)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow validates PR titles and does not perform any write operations, the `contents: read` permission is sufficient. This permission allows the workflow to read repository contents without granting unnecessary write access.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `main` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
