### PR TITLE
ci: Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,9 @@
 name: Tests run on push (Spellcheck and HTML5 validation)
 on: push
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/9](https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/9)

To fix the issue, add a `permissions` block to the workflow file. Since the workflow only requires read access to repository contents for spellchecking and HTML validation, the permissions should be set to `contents: read`. This ensures that the workflow has the minimal permissions necessary to perform its tasks.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs. In this case, adding it at the root level is more efficient since all jobs in the workflow share the same permission requirements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
