### PR TITLE
ci: Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge-conflict-autolabel.yml
+++ b/.github/workflows/merge-conflict-autolabel.yml
@@ -1,4 +1,7 @@
 name: '💥 Auto-Label Merge Conflicts on PRs'
+permissions:
+  contents: read
+  pull-requests: write
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/8](https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/8)

To fix the issue, add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the usage of the `mschilde/auto-label-merge-conflicts` action, the workflow likely needs `contents: read` and `pull-requests: write` permissions. These permissions allow the workflow to read repository contents and label pull requests, respectively.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `triage` job to limit permissions to that specific job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
