### PR TITLE
ci: Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/crowdin-per-language.yml
+++ b/.github/workflows/crowdin-per-language.yml
@@ -1,4 +1,7 @@
 name: Crowdin Sync
+permissions:
+  contents: read
+  pull-requests: write
 
 #on:
 #  push:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/5](https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the provided workflow, the `contents: read` permission is sufficient for most operations, and additional permissions (e.g., `pull-requests: write`) will be added only if necessary for specific steps.

The `permissions` block will be added after the `name` field at the top of the workflow file. This ensures that the permissions apply to all jobs in the workflow unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
