### PR TITLE
ci: Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,4 +1,6 @@
 name: Crowdin Sync
+permissions:
+  contents: read
    
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/4](https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/4)

To address the issue, we will add a `permissions` block to the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the workflow's operations, it appears that only `contents: read` is necessary, as the workflow interacts with Crowdin and does not modify repository contents or create pull requests directly. This change will ensure that the `GITHUB_TOKEN` has limited access, adhering to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
