### PR TITLE
fix: remove bogus heights in content pages

### DIFF
--- a/lang/en/texts/experimental-nutrition-score-france.html
+++ b/lang/en/texts/experimental-nutrition-score-france.html
@@ -1,7 +1,3 @@
-<div id="main_column" class="XXLarge-11 xlarge-10 wide-9 medium-8 columns" style="padding-top: 1REM; height: 4313px;" data-equalizer-watch="">
-
-<!-- Hand column content - how used to remove left column and center glad On Some pages -->
-
 <h1>Nutritional Score - Color Notes - France</h1>
 
 <h2>A system of grades from A to E to simplify nutritional labeling</h2>
@@ -429,4 +425,3 @@ communicated us to calculate the nutritional score. These data come from the wor
 <a href="http://www-smbh.univ-paris13.fr/recherche/laboratoires/69-equipe-de-recherche-en-epidemiologie-nutritionnelle-eren-umr-1153-inserm-u1125-inra-cnam-up13.html">Research Team in Nutritional Epidemiology (EREN)</a>
 of the Paris 13 University / Avicenne Hospital.</p>
 
-</div>

--- a/lang/en/texts/nova.html
+++ b/lang/en/texts/nova.html
@@ -1,6 +1,3 @@
-<div id="main_column" class="xxlarge-11 xlarge-10 large-9 medium-8 columns" style="padding-top: 1rem; height: 3993px;" data-equalizer-watch="">
-
-<!-- main column content - comment used to remove left column and center content on some pages -->  
 <h1 class="emphasized-title">Nova groups for food processing</h1>
 
 <h2 class="emphasized-title">A classification in 4 groups to highlight the degree of processing of foods</h2>
@@ -73,4 +70,3 @@ The NOVA classification assigns a group to food products based on how much proce
 <a href="https://support.openfoodfacts.org/help/en-gb/6">We have listed the Frequently Asked Questions about NOVA here</a><br>
 Feel free to ask additional questions at <a href="mailto:contact@openfoodfacts.org?subject=Question%20about%20the%20Nova%20Groups&body=Source%3A%20the%20NOVA%20methodology%20explainer%20page">contact@openfoodfacts.org</a>
   
-</div>

--- a/lang/en/texts/nutriscore-formula.html
+++ b/lang/en/texts/nutriscore-formula.html
@@ -1,7 +1,3 @@
-<div id="main_column" class="XXLarge-11 xlarge-10 wide-9 medium-8 columns" style="padding-top: 1REM; height: 4313px;" data-equalizer-watch="">
-
-<!-- Hand column content - how used to remove left column and center glad On Some pages -->
-
 <h1>Nutri-Score Nutritional Score and Color grades</h1>
 
 <h2>A system of grades from A to E to simplify nutritional labeling</h2>
@@ -152,4 +148,3 @@ To calculate the nutritional score, it is important to distinguish levels above 
 communicated us to calculate the nutritional score. These data come from the work of the
 <a href="http://www-smbh.univ-paris13.fr/recherche/laboratoires/69-equipe-de-recherche-en-epidemiologie-nutritionnelle-eren-umr-1153-inserm-u1125-inra-cnam-up13.html">Research Team in Nutritional Epidemiology (EREN)</a>
 of the Paris 13 University / Avicenne Hospital.</p>
-</div>

--- a/lang/en/texts/producers.html
+++ b/lang/en/texts/producers.html
@@ -1,9 +1,3 @@
-<div id="main_column" class="xxlarge-11 xlarge-10 large-9 medium-8 columns" style="padding-top:1rem;height:11489px" data-equalizer-watch="">
-
-<!-- main column content - comment used to remove left column and center content on some pages -->  
-	
-
-
 <h1>Guide for producers</h1>
 
 <p>This guide explains why and how producers can directly integrate photos and product data into the Open Food Facts database using our platform for producers.</p>
@@ -239,28 +233,4 @@ If you don't already have a file with your product data, <a href="">we provide a
   
 <h3 id="est_ce_que_les_produits_pour_animaux_les_produits_non_alimentaires_les_cosmetiques_et_les_autres_produits_peuvent_etre_integres_a_open_food_facts">Can animal products, non-food products, cosmetics and other products be integrated into Open Food Facts?</h3>
 <p>We have created specific projects for cosmetics, for animal feed, as well as for other products (Open Beauty Facts, Open Pet Food Facts and Open Products Facts respectively). We are therefore happy to be able to import your products into the project that suits them.</p>
-</div>
 
-<script>
-	function onMount(fn) {
-		if (document.readyState === "loading") {
-			document.addEventListener("DOMContentLoaded", fn);
-		} else {
-			fn();
-		}
-	}
-
-	onMount(() => {
-		function sendHeight() {
-			const height = document.body.scrollHeight;
-			console.debug("Calculated height: " + height);
-			if (typeof parent !== 'undefined' && parent !== window) {
-				parent.postMessage({ frameHeight: height }, '*');
-			}
-		}
-		// Send the height on initial load
-		sendHeight();
-		// Send the height whenever the window is resized
-		window.addEventListener("resize", sendHeight);
-	});
-</script>

--- a/lang/fr/texts/experimental-nutrition-score-france.html
+++ b/lang/fr/texts/experimental-nutrition-score-france.html
@@ -1,7 +1,3 @@
-<div id="main_column" class="XXLarge-11 xlarge-10 wide-9 medium-8 columns" style="padding-top: 1REM; height: 4313px;" data-equalizer-watch="">
-
-<!-- Hand column content - how used to remove left column and center glad On Some pages -->  
-
 <h1>Score nutritionnel - Notes de couleur - France</h1>
 
 <h2>Un système de notes de A à E pour simplifier l'étiquetage nutritionnel</h2>
@@ -399,4 +395,3 @@ Pour le calcul du score nutritionnel, l'important est de distinguer les teneurs 
 <h2>Remerciements</h2>
 <p>Nous remercions le Professeur Serge Hercberg et le Dr. Chantal Julia pour leur aide et les données qu'ils nous ont communiquées pour calculer le score nutritionnel. Ces données proviennent du travail de l'équipe de recherche <a href="http://www-smbh.univ-paris13.fr/recherche/laboratoires/69-equipe-de-recherche-en-epidemiologie-nutritionnelle-eren-umr-1153-inserm-u1125-inra-cnam-up13.html"> en épidémiologie nutritionnelle (EREN) </a> de l'Université Paris 13 / Hôpital Avicenne.</p>
 
-</div>

--- a/lang/fr/texts/nova.html
+++ b/lang/fr/texts/nova.html
@@ -1,6 +1,3 @@
-<div id="main_column" class="xxlarge-11 xlarge-10 large-9 medium-8 columns" style="padding-top: 1rem; height: 3993px;" data-equalizer-watch="">
-
-<!-- main column content - comment used to remove left column and center content on some pages -->  
 <h1 class="emphasized-title">Classification NOVA pour la transformation des aliments</h1>
 
 <h2 class="emphasized-title">Une classification en 4 groupes pour mettre en évidence le degré de transformation des aliments</h2>
@@ -71,5 +68,3 @@ La classification NOVA assigne un groupe aux produits alimentaires en fonction d
 <h2 class="emphasized-title">Foire Aux Questions</h2>
 
 <a href="https://support.openfoodfacts.org/help/en-gb/6"> Nous avons listées les questions fréquemment posées au sujet de NOVA ici </a> <br> N'hésitez pas à poser des questions à cette adresse : <a href="mailto:contact@openfoodfacts.org?subject=Question%20about%20the%20Nova%20Groups&body=Source%3A%20the%20NOVA%20methodology%20explainer%20page">contact@openfoodfacts.org</a>
-  
-</div>

--- a/lang/fr/texts/nutriscore-formula.html
+++ b/lang/fr/texts/nutriscore-formula.html
@@ -1,7 +1,3 @@
-<div id="main_column" class="XXLarge-11 xlarge-10 wide-9 medium-8 columns" style="padding-top: 1REM; height: 4313px;" data-equalizer-watch="">
-
-<!-- Hand column content - how used to remove left column and center glad On Some pages -->
-
 <h1>Nutri-Score - Score nutritionnel et notes de couleur</h1>
 
 <h2>Un système de notes de A à E pour simplifier l'étiquetage nutritionnel</h2>
@@ -143,4 +139,3 @@ Pour le calcul du score nutritionnel, l'important est de distinguer les teneurs 
 <p>Remarque: les tubercules comme les pommes de terre et les patates douces ne sont pas considérés comme des légumes pour calculer le score nutritionnel.</p>
 <h2>Remerciements</h2>
 <p>Nous remercions le Professeur Serge Hercberg et le Dr. Chantal Julia pour leur aide et les données qu'ils nous ont communiquées pour calculer le score nutritionnel. Ces données proviennent du travail de l'équipe de recherche <a href="http://www-smbh.univ-paris13.fr/recherche/laboratoires/69-equipe-de-recherche-en-epidemiologie-nutritionnelle-eren-umr-1153-inserm-u1125-inra-cnam-up13.html"> en épidémiologie nutritionnelle (EREN) </a> de l'Université Paris 13 / Hôpital Avicenne.</p>
-</div>

--- a/lang/fr/texts/producers.html
+++ b/lang/fr/texts/producers.html
@@ -1,9 +1,3 @@
-<div id="main_column" class="xxlarge-11 xlarge-10 large-9 medium-8 columns" style="padding-top:1rem;height:11489px" data-equalizer-watch="">
-
-<!-- main column content - comment used to remove left column and center content on some pages -->  
-	
-
-
 <h1>Guide pour les producteurs</h1>
 
 <p>Ce guide explique pourquoi et comment les producteurs peuvent directement intégrer des photos et des données de produit dans la base de données Open Food Facts en utilisant notre plateforme.</p>
@@ -239,28 +233,3 @@ Si vous n'avez pas encore de fichier avec vos données produit,<a href="">nous f
   
 <h3 id="est_ce_que_les_produits_pour_animaux_les_produits_non_alimentaires_les_cosmetiques_et_les_autres_produits_peuvent_etre_integres_a_open_food_facts">Les produits d'origine animale, les produits non alimentaires, les cosmétiques et d'autres produits peuvent-ils être intégrés dans Open Food Facts ?</h3>
 <p>Nous avons créé des projets spécifiques pour les cosmétiques, l'alimentation animale et les autres produits (respectivement Open Beauty Facts, Open Pet Food Facts et Open Products Facts). Nous sommes donc heureux de pouvoir importer vos produits dans le projet qui leur convient.</p>
-</div>
-
-<script>
-	function onMount(fn) {
-		if (document.readyState === "loading") {
-			document.addEventListener("DOMContentLoaded", fn);
-		} else {
-			fn();
-		}
-	}
-
-	onMount(() => {
-		function sendHeight() {
-			const height = document.body.scrollHeight;
-			console.debug("Calculated height: " + height);
-			if (typeof parent !== 'undefined' && parent !== window) {
-				parent.postMessage({ frameHeight: height }, '*');
-			}
-		}
-		// Send the height on initial load
-		sendHeight();
-		// Send the height whenever the window is resized
-		window.addEventListener("resize", sendHeight);
-	});
-</script>


### PR DESCRIPTION
Some content pages contain code that was copy pasted from generated equalizer code with fixed heights, removing it.

Fixes https://github.com/openfoodfacts/openfoodfacts-server/issues/12345