### PR TITLE
docs: typo fixup: `ot` -> `of`

### DIFF
--- a/lang/aa/texts/terms-of-use.html
+++ b/lang/aa/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ach/texts/terms-of-use.html
+++ b/lang/ach/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/af/texts/terms-of-use.html
+++ b/lang/af/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ak/texts/terms-of-use.html
+++ b/lang/ak/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/am/texts/terms-of-use.html
+++ b/lang/am/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/as/texts/terms-of-use.html
+++ b/lang/as/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ast/texts/terms-of-use.html
+++ b/lang/ast/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/az/texts/terms-of-use.html
+++ b/lang/az/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/be/texts/terms-of-use.html
+++ b/lang/be/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ber/texts/terms-of-use.html
+++ b/lang/ber/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/bm/texts/terms-of-use.html
+++ b/lang/bm/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/bn/texts/terms-of-use.html
+++ b/lang/bn/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/bo/texts/terms-of-use.html
+++ b/lang/bo/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/br/texts/terms-of-use.html
+++ b/lang/br/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Lañvazioù</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/bs/texts/terms-of-use.html
+++ b/lang/bs/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ce/texts/terms-of-use.html
+++ b/lang/ce/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/chr/texts/terms-of-use.html
+++ b/lang/chr/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/co/texts/terms-of-use.html
+++ b/lang/co/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/crs/texts/terms-of-use.html
+++ b/lang/crs/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/cv/texts/terms-of-use.html
+++ b/lang/cv/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/cy/texts/terms-of-use.html
+++ b/lang/cy/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/el/texts/terms-of-use.html
+++ b/lang/el/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/en/texts/terms-of-use.html
+++ b/lang/en/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/en_AU/texts/terms-of-use.html
+++ b/lang/en_AU/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/en_GB/texts/terms-of-use.html
+++ b/lang/en_GB/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/eo/texts/terms-of-use.html
+++ b/lang/eo/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/et/texts/terms-of-use.html
+++ b/lang/et/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/eu/texts/terms-of-use.html
+++ b/lang/eu/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/fa/texts/terms-of-use.html
+++ b/lang/fa/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/fil/texts/terms-of-use.html
+++ b/lang/fil/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/fo/texts/terms-of-use.html
+++ b/lang/fo/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ga/texts/terms-of-use.html
+++ b/lang/ga/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Ceadúnais</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/gd/texts/terms-of-use.html
+++ b/lang/gd/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/gl/texts/terms-of-use.html
+++ b/lang/gl/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/gu/texts/terms-of-use.html
+++ b/lang/gu/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ha/texts/terms-of-use.html
+++ b/lang/ha/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/hi/texts/terms-of-use.html
+++ b/lang/hi/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/hr/texts/terms-of-use.html
+++ b/lang/hr/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ht/texts/terms-of-use.html
+++ b/lang/ht/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/hu/texts/terms-of-use.html
+++ b/lang/hu/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/hy/texts/terms-of-use.html
+++ b/lang/hy/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ii/texts/terms-of-use.html
+++ b/lang/ii/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/is/texts/terms-of-use.html
+++ b/lang/is/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/iu/texts/terms-of-use.html
+++ b/lang/iu/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ja/texts/terms-of-use.html
+++ b/lang/ja/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/jv/texts/terms-of-use.html
+++ b/lang/jv/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ka/texts/terms-of-use.html
+++ b/lang/ka/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/kaa/texts/terms-of-use.html
+++ b/lang/kaa/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/kab/texts/terms-of-use.html
+++ b/lang/kab/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/kk/texts/terms-of-use.html
+++ b/lang/kk/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/km/texts/terms-of-use.html
+++ b/lang/km/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/kmr/texts/terms-of-use.html
+++ b/lang/kmr/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/kmr_TR/texts/terms-of-use.html
+++ b/lang/kmr_TR/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/kn/texts/terms-of-use.html
+++ b/lang/kn/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ku/texts/terms-of-use.html
+++ b/lang/ku/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/kw/texts/terms-of-use.html
+++ b/lang/kw/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ky/texts/terms-of-use.html
+++ b/lang/ky/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/la/texts/terms-of-use.html
+++ b/lang/la/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/lb/texts/terms-of-use.html
+++ b/lang/lb/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/lo/texts/terms-of-use.html
+++ b/lang/lo/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/lt/texts/terms-of-use.html
+++ b/lang/lt/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/me/texts/terms-of-use.html
+++ b/lang/me/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/mg/texts/terms-of-use.html
+++ b/lang/mg/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/mi/texts/terms-of-use.html
+++ b/lang/mi/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ml/texts/terms-of-use.html
+++ b/lang/ml/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/mn/texts/terms-of-use.html
+++ b/lang/mn/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/mr/texts/terms-of-use.html
+++ b/lang/mr/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ms/texts/terms-of-use.html
+++ b/lang/ms/texts/terms-of-use.html
@@ -183,7 +183,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/mt/texts/terms-of-use.html
+++ b/lang/mt/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/my/texts/terms-of-use.html
+++ b/lang/my/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/nb/texts/terms-of-use.html
+++ b/lang/nb/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Lisenser</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ne/texts/terms-of-use.html
+++ b/lang/ne/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/nn/texts/terms-of-use.html
+++ b/lang/nn/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/no/texts/terms-of-use.html
+++ b/lang/no/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/nr/texts/terms-of-use.html
+++ b/lang/nr/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/oc/texts/terms-of-use.html
+++ b/lang/oc/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/or/texts/terms-of-use.html
+++ b/lang/or/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/pa/texts/terms-of-use.html
+++ b/lang/pa/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/pl/texts/terms-of-use.html
+++ b/lang/pl/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/qu/texts/terms-of-use.html
+++ b/lang/qu/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/rm/texts/terms-of-use.html
+++ b/lang/rm/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ry/texts/terms-of-use.html
+++ b/lang/ry/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/sa/texts/terms-of-use.html
+++ b/lang/sa/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/sat/texts/terms-of-use.html
+++ b/lang/sat/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/sc/texts/terms-of-use.html
+++ b/lang/sc/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/sco/texts/terms-of-use.html
+++ b/lang/sco/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/sd/texts/terms-of-use.html
+++ b/lang/sd/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/sg/texts/terms-of-use.html
+++ b/lang/sg/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/sh/texts/terms-of-use.html
+++ b/lang/sh/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/si/texts/terms-of-use.html
+++ b/lang/si/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/sk/texts/terms-of-use.html
+++ b/lang/sk/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/sl/texts/terms-of-use.html
+++ b/lang/sl/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licence</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/sma/texts/terms-of-use.html
+++ b/lang/sma/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/sn/texts/terms-of-use.html
+++ b/lang/sn/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/so/texts/terms-of-use.html
+++ b/lang/so/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/son/texts/terms-of-use.html
+++ b/lang/son/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/sq/texts/terms-of-use.html
+++ b/lang/sq/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/sr/texts/terms-of-use.html
+++ b/lang/sr/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/sr_CS/texts/terms-of-use.html
+++ b/lang/sr_CS/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/sr_RS/texts/terms-of-use.html
+++ b/lang/sr_RS/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ss/texts/terms-of-use.html
+++ b/lang/ss/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/st/texts/terms-of-use.html
+++ b/lang/st/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/sw/texts/terms-of-use.html
+++ b/lang/sw/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ta/texts/terms-of-use.html
+++ b/lang/ta/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/te/texts/terms-of-use.html
+++ b/lang/te/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/tg/texts/terms-of-use.html
+++ b/lang/tg/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/th/texts/terms-of-use.html
+++ b/lang/th/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ti/texts/terms-of-use.html
+++ b/lang/ti/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/tl/texts/terms-of-use.html
+++ b/lang/tl/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/tn/texts/terms-of-use.html
+++ b/lang/tn/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ts/texts/terms-of-use.html
+++ b/lang/ts/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/tt/texts/terms-of-use.html
+++ b/lang/tt/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/tw/texts/terms-of-use.html
+++ b/lang/tw/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ty/texts/terms-of-use.html
+++ b/lang/ty/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/tzl/texts/terms-of-use.html
+++ b/lang/tzl/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ug/texts/terms-of-use.html
+++ b/lang/ug/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ur/texts/terms-of-use.html
+++ b/lang/ur/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/uz/texts/terms-of-use.html
+++ b/lang/uz/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/val/texts/terms-of-use.html
+++ b/lang/val/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/ve/texts/terms-of-use.html
+++ b/lang/ve/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/vec/texts/terms-of-use.html
+++ b/lang/vec/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/vi/texts/terms-of-use.html
+++ b/lang/vi/texts/terms-of-use.html
@@ -184,7 +184,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/vls/texts/terms-of-use.html
+++ b/lang/vls/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/wa/texts/terms-of-use.html
+++ b/lang/wa/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/wo/texts/terms-of-use.html
+++ b/lang/wo/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/xh/texts/terms-of-use.html
+++ b/lang/xh/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/yi/texts/terms-of-use.html
+++ b/lang/yi/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/yo/texts/terms-of-use.html
+++ b/lang/yo/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/zea/texts/terms-of-use.html
+++ b/lang/zea/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>

--- a/lang/zh_CN/texts/terms-of-use.html
+++ b/lang/zh_CN/texts/terms-of-use.html
@@ -237,7 +237,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>许可证</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,

--- a/lang/zh_HK/texts/terms-of-use.html
+++ b/lang/zh_HK/texts/terms-of-use.html
@@ -242,7 +242,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,

--- a/lang/zh_TW/texts/terms-of-use.html
+++ b/lang/zh_TW/texts/terms-of-use.html
@@ -241,7 +241,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,

--- a/lang/zu/texts/terms-of-use.html
+++ b/lang/zu/texts/terms-of-use.html
@@ -185,7 +185,7 @@ for information and data, and under the <a href="https://creativecommons.org/lic
 
 <h3>Licences</h3>
 
-<p>Three licences apply to the different parts ot the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
+<p>Three licences apply to the different parts of the products database of Open Food Facts. The licences are free licences that authorize the use and reproduction of the content for all purposes, including commercial use, under certain conditions,
 especially the attribution and the sharing under the same condition of derivative works.</p>
 
 <p>The Open Food Facts database is available under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Database License</a>.</p>


### PR DESCRIPTION
### What
Typo fixup for the `terms-of-service.html` page in each affected language.

I spotted this while preparing to print copies of the ODBL and Database Contents License files to bring with me for OpenFoodFacts Days 2025 (because I brought printed copies of products from the database with me for a workshop).

### Screenshot
N/A

### Fixes bug(s)
- Resolves #794.

### Part of 
N/A