### PR TITLE
ci: Add permissions to the workflow: .github/workflows/preprod-deploy.yml

### DIFF
--- a/.github/workflows/preprod-deploy.yml
+++ b/.github/workflows/preprod-deploy.yml
@@ -1,5 +1,7 @@
 name: Preprod Deployment CI
 
+permissions: {}
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/7](https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/7)

To fix the problem, explicitly specify a `permissions` block either at the workflow root (recommended for all jobs) or at the individual job level. Since this workflow does not seem to use the `GITHUB_TOKEN` at all, we can set `permissions: {}`
at the root which results in no permissions for the `GITHUB_TOKEN`. This is the strictest and most secure setting. Adding the permissions block at the top (after `name:` and before or after `on:`) is sufficient. No further code or external changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
