### PR TITLE
ci: Add permissions to the workflow: .github/workflows/build-knowledge-panels.yml

### DIFF
--- a/.github/workflows/build-knowledge-panels.yml
+++ b/.github/workflows/build-knowledge-panels.yml
@@ -1,4 +1,6 @@
 name: Build HTML pages for Knowledge cards related to Taxonomy entries
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/3](https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/3)

To fix the problem, we need to set a `permissions` block at the workflow or job level. Since the `update-assets` job is the only job, we can add it at the root of the workflow YAML. However, this workflow uses the `peter-evans/create-pull-request` action, which requires `contents: write` (to push new commits and branches) and optionally `pull-requests: write` (to open a PR). At a minimum, we should grant `contents: write` at the workflow level, and can optionally add `pull-requests: write` for best compatibility. The change goes at the root, immediately after the `name:` field and before the `on:` block.

- Insert a `permissions:` block with values:
  ```yaml
  permissions:
    contents: write
  ```
- Optionally, add `pull-requests: write` if you want to follow the full CodeQL guidance and future-proof for actions that require explicit permission to open pull requests.
- This only requires a direct edit to lines 2–3.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
