### PR TITLE
fix(web): migrate Google Podcast icon to YouTube Podcasts

### DIFF
--- a/lang/en/texts/cop26/blocks/google-podcast.html
+++ b/lang/en/texts/cop26/blocks/google-podcast.html
@@ -15,9 +15,9 @@
 <!--<a href="https://podcasts.apple.com/podcast/id1560969127?mt=2&amp;ls=1">
 <img alt="Listen on Apple Podcasts" src="https://static.openfoodfacts.org/images/cop26/podcast/apple-podcasts.jpeg">
 </a>-->
-<!--<a href="https://podcasts.google.com/feed/aHR0cDovL3BsYW5ldHByb2dyZXNzLmxpYnN5bi5jb20vcGxheWVyZm0">
-<img alt="Listen on Google Podcasts" src="https://static.openfoodfacts.org/images/cop26/podcast/google-podcasts.jpeg">
-</a>-->
+<a href="https://www.youtube.com/podcasts">
+  <img alt="Listen on YouTube Podcasts" src="https://static.openfoodfacts.org/images/cop26/podcast/youtube-podcasts.jpeg">
+</a>
 <a href="https://open.spotify.com/show/0Pkg6vaAMUKE4sqyqCXfWY?si=yi09yTzeQKm020hsK3WP0w">
 <img alt="Listen on Spotify" src="https://static.openfoodfacts.org/images/cop26/podcast/spotify.jpeg">
 </a>
@@ -35,10 +35,10 @@
 <!--<a href="https://podcasts.apple.com/podcast/id1560969127?mt=2&amp;ls=1">
 <img alt="Listen on Apple Podcasts" src="https://static.openfoodfacts.org/images/cop26/podcast/apple-podcasts.jpeg">
 </a>-->
-		<!--
-<a href="https://podcasts.google.com/feed/aHR0cDovL3BsYW5ldHByb2dyZXNzLmxpYnN5bi5jb20vcGxheWVyZm0">
-<img alt="Listen on Google Podcasts" src="https://static.openfoodfacts.org/images/cop26/podcast/google-podcasts.jpeg">
-</a>-->
+		<a href="https://www.youtube.com/podcasts">
+  <img alt="Listen on YouTube Podcasts" src="https://static.openfoodfacts.org/images/cop26/podcast/youtube-podcasts.jpeg">
+    </a>
+
 <a href="https://open.spotify.com/show/0Pkg6vaAMUKE4sqyqCXfWY?si=yi09yTzeQKm020hsK3WP0w">
 <img alt="Listen on Spotify" src="https://static.openfoodfacts.org/images/cop26/podcast/spotify.jpeg">
 </a>


### PR DESCRIPTION
### What
This PR migrates the deprecated Google Podcasts icon to YouTube Podcasts
by updating the podcast link and icon.

### Screenshot
Not applicable (static HTML change).

### Fixes bug(s)
Fixes #721

### Part of
N/A
