### PR TITLE
fix(knowledge-panels): fix ValueError formatting for unknown flavor

### DIFF
--- a/knowledge_panels/build_html.py
+++ b/knowledge_panels/build_html.py
@@ -116,7 +116,8 @@ def build_content_from_file(
         file_path: the input YAML file path
     """
     if flavor not in ("obf", "off", "opf", "opff"):
-        raise ValueError("Ignoring file %s: unknown flavor %s", file_path, flavor)
+        raise ValueError(f"Ignoring file {file_path}: unknown flavor {flavor}")
+
 
     tag_type, country, lang = extract_information_from_file_name(file_path)
     if tag_type not in (


### PR DESCRIPTION
### What
- Fix incorrect `ValueError` usage where a tuple was passed instead of a formatted string when encountering an unknown flavor.
- This ensures the exception message is clear and correctly raised at runtime.
### Screenshot
- Not applicable (code change only)
### Fixes bug(s)
- Not applicable
### Part of
- Not applicable