### PR TITLE
fix: fix truncated text issue in nova.html

### DIFF
--- a/lang/en/texts/nova.html
+++ b/lang/en/texts/nova.html
@@ -1,4 +1,4 @@
-<div id="main_column" class="xxlarge-11 xlarge-10 large-9 medium-8 columns" style="padding-top: 1rem; height: 3993px;" data-equalizer-watch="">
+<div id="main_column" class="xxlarge-11 xlarge-10 large-9 medium-8 columns" style="padding-top: 1rem;" data-equalizer-watch="">
 
 <!-- main column content - comment used to remove left column and center content on some pages -->  
 <h1 class="emphasized-title">Nova groups for food processing</h1>


### PR DESCRIPTION
The main column had a fixed height.
Closes #863.

Before the fix:
<img width="1443" height="939" alt="Capture d’écran du 2025-12-29 09-58-23" src="https://github.com/user-attachments/assets/a5b80ec6-dd51-454e-9803-9f6ca5c3c84c" />

After the fix:

<img width="1443" height="939" alt="Capture d’écran du 2025-12-29 10-04-25" src="https://github.com/user-attachments/assets/aabc31cd-d39b-4a2f-8a58-f4e780c1fe40" />
