### PR TITLE
docs: deprecate presentations.html and link to Open Food Facts wiki

### DIFF
--- a/lang/aa/texts/presentations.html
+++ b/lang/aa/texts/presentations.html
@@ -1,3 +1,9 @@
+<div style="border: 2px solid #e74c3c; padding: 16px; margin:20px 0 ; background: #fdecea;">
+   <strong>⚠️ Deprecated page</strong> <br>
+     This page is no longer actively maintained.
+     Please refer to the Open Food Facts wiki for up-to-date information:
+         <a href="https://wiki.openfoodfacts.org/" target="_blank" rel="noopener noreferrer">https://wiki.openfoodfacts.org/</a>
+</div>
 <h2>Presentations</h2>
 A first step to contribute to Open Food Facts is to present it to you friends and family.<br>You can get on Twitter, Facebook or Google Plus and ask a few friends and family to join the project.<br>
 


### PR DESCRIPTION
This PR adds a clear deprecation notice to presentations.html and links to the Open Food Facts wiki, which is actively maintained.

The goal is to guide users toward a single, up-to-date source of information instead of maintaining outdated static content.