### PR TITLE
docs: clarify percentage meaning in FAQ

### DIFF
--- a/lang/en/texts/faq.html
+++ b/lang/en/texts/faq.html
@@ -10,6 +10,7 @@
 <li><a href="#adding_my_products">I am a food product manufacturer, can I add my own products?</a></li>
 <li><a href="#difference_with_other_services">What is the difference with other web sites, services and mobile applications that already allow to view food products information?</a></li>
 <li><a href="#economic_model">What is Open Food Facts' economic model ?</a></li>
+<li><a href="#nutrient_comparison_percentage">What does the percentage next to nutrients mean (e.g., +4%)?</a></li>
 </ul>
 
 
@@ -76,6 +77,18 @@ write articles and studies. They are free to make the resulting work freely avai
 <p>We are also strictly independent from the food industry, and all the services and software we build are free. For example, our Platform for Producers is totally free, 
 
  and we are all the more pleased with that because we think it might help them improve their products. 
+
+
+<h2 id="nutrient_comparison_percentage">What does the percentage next to nutrients mean (e.g., +4%)?</h2>
+
+<p>When you see a percentage like "+4%" next to a nutrient on a product page, it shows how this product compares to other products in the same category:</p>
+
+<ul>
+<li><strong>Positive value (+4%)</strong> = This product has MORE of that nutrient than the average for similar products</li>
+<li><strong>Negative value (-4%)</strong> = This product has LESS of that nutrient than the average for similar products</li>
+</ul>
+
+<p>For example, if salt shows "+10%", it means this cereal has 10% more salt than the average cereal. This helps you quickly see if a product is healthier or less healthy than similar items.</p>
 
 
 <p>&nbsp;</p>

--- a/lang/en/texts/faq.html
+++ b/lang/en/texts/faq.html
@@ -10,7 +10,7 @@
 <li><a href="#adding_my_products">I am a food product manufacturer, can I add my own products?</a></li>
 <li><a href="#difference_with_other_services">What is the difference with other web sites, services and mobile applications that already allow to view food products information?</a></li>
 <li><a href="#economic_model">What is Open Food Facts' economic model ?</a></li>
-<li><a href="#nutrient_comparison_percentage">What does the percentage next to nutrients mean (e.g., +4%)?</a></li>
+<li><a href="#nutrient_comparison_percentage">What does the percentage next to nutrients mean (e.g. +4%)?</a></li>
 </ul>
 
 


### PR DESCRIPTION
Added clarification in the FAQ explaining the meaning of percentage differences in the "products in the same category" column.

Positive values indicate that the product has higher values than the category average, while negative values indicate lower values.

This helps resolve confusion about what values like "+4%" represent.