### PR TITLE
docs: Make the Hunger Games more discoverable

### DIFF
--- a/lang/en/texts/contribute.html
+++ b/lang/en/texts/contribute.html
@@ -49,7 +49,7 @@ Whether you are already a very involved contributor or have just arrived and wan
 		<h3>Complete products</h3>
     <p>We need to categorize products and extract ingredients lists and nutrition facts to
 analyze their nutritional quality, determine if they are suitable for vegans and vegetatarians and much more!</p>
-    <p><a href="/help-complete-products">You can help us complete products</a> by selecting and cropping photos and filling in information.</p>
+    <p><a href="/help-complete-products">You can help us complete products</a> by selecting and cropping photos and filling in information, or by participating in our <a href="/contribute-to-open-food-facts-by-playing">Hunger Games</a>.</p>
 
 	</div>
 

--- a/lang/fr/texts/contribute.html
+++ b/lang/fr/texts/contribute.html
@@ -48,7 +48,7 @@ Que vous soyez déjà un contributeur très impliqué ou que vous veniez d'arriv
 	<div class="medium-3 columns">
 		<h3>Compléter des produits</h3>
     <p>Nous devons catégoriser les produits, extraire la liste des ingrédients et leurs valeurs nutritives afin d'analyser leurs qualités nutritionnelles, déterminer s'ils conviennent aux végétaliens et végétariens et bien plus encore !</p>
-    <p><a href="/help-complete-products">Vous pouvez nous aider à compléter les données des produits</a> en sélectionnant et recadrant les photos, puis en saisissant des informations.</p>
+    <p><a href="/help-complete-products">Vous pouvez nous aider à compléter les données des produits</a> en sélectionnant et recadrant les photos, puis en saisissant des informations, ou en participant à nos <a href="/contribute-to-open-food-facts-by-playing">Hunger Games</a>.</p>
 
 	</div>
 


### PR DESCRIPTION
Hunger Games is great in that it's a very easy way to improve OFF's completeness. Yet the website has no link to Hunger Games; making it all but impossible for users to learn about it except through external sources like word of mouth in the forums or other places. So make Hunger Games more visible by adding links to the as-yet unreferenced contribute-to-open-food-facts-by-playing page.