### PR TITLE
ci: add permissions for semantic pr action

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
Add an explicit `permissions` block at the workflow root (top-level) 

- `contents: read`
- `pull-requests: read`