### PR TITLE
ci: check strings permissions

### DIFF
--- a/.github/workflows/check_strings.yml
+++ b/.github/workflows/check_strings.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'lang/**/texts/index.html'
 
+permissions:
+  contents: read
+
 jobs:
   check_strings:
     runs-on: ubuntu-latest


### PR DESCRIPTION

Add an explicit `permissions` block in `.github/workflows/check_strings.yml` at the workflow root (after `on:` and before `jobs:`), setting the minimal required scope.

Best fix here without changing functionality:
- Add:
  - `permissions:`
  - `  contents: read`


