### PR TITLE
ci: Workflow permissions for crowdin.yml

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - crowdin-trigger
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   synchronize-with-crowdin-classic:
     name: Synchronize with crowdin


### PR DESCRIPTION

Add an explicit `permissions` block to `.github/workflows/crowdin.yml` so the `GITHUB_TOKEN` is least-privileged and documented.  

- `contents: write` (needed to push translation branch/commits)
- `pull-requests: write` (needed to create/update PRs)
