### PR TITLE
fix: permissions for check_includes.yml

### DIFF
--- a/.github/workflows/check_includes.yml
+++ b/.github/workflows/check_includes.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'impossiblecondition**.html'
 
+permissions:
+  contents: read
+
 jobs:
   check-includes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/76](https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/76)

Add an explicit `permissions` block to `.github/workflows/check_includes.yml` to constrain `GITHUB_TOKEN` to least privilege.  
For this workflow, `contents: read` is sufficient (needed for checkout/read access). No functional behavior change is expected because the workflow only checks out code, installs a dependency, and runs a read-only validation script.

**Best single fix:** insert at workflow root (after `on:` block, before `jobs:`):

```yml
permissions:
  contents: read
```

This applies to all jobs in the workflow and resolves the CodeQL finding cleanly without altering job logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
