### PR TITLE
fix: permissions for crowdin.yml

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - crowdin-trigger
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   synchronize-with-crowdin-classic:
     name: Synchronize with crowdin


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/78](https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/78)

Add an explicit `permissions` block to `.github/workflows/crowdin.yml` so the workflow does not inherit broad defaults.

Best fix here (without changing behavior) is to define permissions at the workflow root (applies to all jobs unless overridden). Since this job checks out code and creates/updates localization PRs/branches via the Crowdin action, grant:
- `contents: write` (needed for committing/pushing branches),
- `pull-requests: write` (needed to create/update PRs).

Edit region:
- `.github/workflows/crowdin.yml` near the top, directly after the `on:` trigger block and before `jobs:`.

No imports/dependencies/methods are needed—just YAML key insertion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
