### PR TITLE
fix: permissions for crowdin-split.yml

### DIFF
--- a/.github/workflows/crowdin-split.yml
+++ b/.github/workflows/crowdin-split.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/77](https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/77)

Add an explicit `permissions` block to `.github/workflows/crowdin-split.yml` so the `GITHUB_TOKEN` scope is intentionally constrained. The best single fix is to define permissions at the workflow root (applies to all jobs unless overridden), keeping behavior unchanged while documenting required access.

In this file, insert a root-level `permissions` section between `on:` and `jobs:`. Since this workflow checks out code and uses Crowdin GitHub Action with PR metadata (`pull_request_title`), a practical least-privilege baseline is:

- `contents: write` (needed if the action commits/pushes translation updates)
- `pull-requests: write` (needed to create/update PRs)

If your exact Crowdin mode only reads contents, this could be tightened later, but this is the safest no-regression explicit permission set for the shown behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
