### PR TITLE
fix: permissions for release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,9 @@
        - main
  jobs:
    release-please:
+     permissions:
+       contents: write
+       pull-requests: write
      runs-on: ubuntu-slim
      steps:
        - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/81](https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/81)

Add an explicit `permissions` block in `.github/workflows/release-please.yml`.  
Best single fix without changing intended functionality: define permissions at the **job level** for `release-please`, granting only what release-please needs to create/update releases and PRs.

For this workflow, add under `jobs.release-please`:
- `contents: write` (create/update release tags/releases/changelog commits as needed)
- `pull-requests: write` (open/update release PRs)

This keeps scope limited to this job and avoids over-permissioning other jobs (if added later). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
