### PR TITLE
fix: permissions for merge-conflict-autolabel.yml

### DIFF
--- a/.github/workflows/merge-conflict-autolabel.yml
+++ b/.github/workflows/merge-conflict-autolabel.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/79](https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/79)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is constrained to only what this workflow needs.  
For this workflow, the action labels pull requests, so a safe minimal set is:

- `contents: read` (read repository metadata/content)
- `pull-requests: write` (apply/update labels on PRs)

Edit **`.github/workflows/merge-conflict-autolabel.yml`** by inserting the `permissions` block at the top level (after `on:` section and before `concurrency:` is a clean placement). This preserves behavior while enforcing least privilege and satisfying CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
