### PR TITLE
fix: permissions for .github/workflows/push.yml

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,9 @@
 name: Tests run on push (Spellcheck and HTML5 validation)
 on: push
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/80](https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/80)

Add an explicit `permissions` block at the workflow root so all jobs in this workflow inherit least-privilege defaults. For this file, `contents: read` is the appropriate minimal permission and aligns with CodeQL guidance.

**Best fix in this file:**  
- Edit `.github/workflows/push.yml`  
- Insert at the top level (after `on:` is a clear location) a block:
  - `permissions:`
  - `  contents: read`

This does not change workflow behavior for current steps (checkout still works) but ensures token scope is explicitly limited and stable across repo/org default changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
