### PR TITLE
fix: permissions for crowdin-per-language.yml

### DIFF
--- a/.github/workflows/crowdin-per-language.yml
+++ b/.github/workflows/crowdin-per-language.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - crowdin-trigger-per-language
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   synchronize-with-crowdin-matrix:
     name: Synchronize with crowdin (matrix)


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/39](https://github.com/openfoodfacts/openfoodfacts-web/security/code-scanning/39)

Add an explicit `permissions` block in `.github/workflows/crowdin-per-language.yml` so the workflow does not inherit potentially broad defaults.  
Best single fix without changing behavior: define permissions at the workflow root (applies to all jobs) with the minimum needed for this workflow’s operations:

- `contents: write` (to commit/push localization branch updates if action does so)
- `pull-requests: write` (to create/update PRs)

This is the least-intrusive change and keeps existing job logic untouched. Insert the block right after the `on:` trigger section and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
